### PR TITLE
Remove Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,5 @@
 # Example Site settings
 
-#google_analytics: UA-NNNNNNNN-N
-
 #header_pages:
 #  - index.md
 #  - about.md

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,8 +1,0 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
-<script>
-  window['ga-disable-{{ site.google_analytics }}'] = window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1";
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '{{ site.google_analytics }}');
-</script>


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you *must* keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/